### PR TITLE
Promenjena tekstura za skybox

### DIFF
--- a/engine/test/app/src/MainController.cpp
+++ b/engine/test/app/src/MainController.cpp
@@ -71,13 +71,19 @@ void MainController::update_camera() {
     auto camera = engine::core::Controller::get<engine::graphics::GraphicsController>()->camera();
     float dt = platform->dt();
 
-    if (platform->key(engine::platform::KEY_W).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::FORWARD, dt); }
-    if (platform->key(engine::platform::KEY_S).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::BACKWARD, dt); }
-    if (platform->key(engine::platform::KEY_A).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::LEFT, dt); }
-    if (platform->key(engine::platform::KEY_D).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::RIGHT, dt); }
-    // Dodaj vertikalno kretanje:
-    if (platform->key(engine::platform::KEY_E).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::UP, dt); }
-    if (platform->key(engine::platform::KEY_Q).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::DOWN, dt); }
+    // Ako SHIFT (npr. levi SHIFT) pritisnut, povećaj faktor brzine
+    float speedMultiplier = 1.0f;
+    if (platform->key(engine::platform::KeyId::KEY_LEFT_SHIFT).state() == engine::platform::Key::State::Pressed) {
+        speedMultiplier = 4.0f;// Možeš podesiti faktor po želji (ovde 2x brže)
+    }
+
+    if (platform->key(engine::platform::KEY_W).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::FORWARD, dt * speedMultiplier); }
+    if (platform->key(engine::platform::KEY_S).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::BACKWARD, dt * speedMultiplier); }
+    if (platform->key(engine::platform::KEY_A).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::LEFT, dt * speedMultiplier); }
+    if (platform->key(engine::platform::KEY_D).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::RIGHT, dt * speedMultiplier); }
+    // Vertikalno kretanje:
+    if (platform->key(engine::platform::KEY_E).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::UP, dt * speedMultiplier); }
+    if (platform->key(engine::platform::KEY_Q).state() == engine::platform::Key::State::Pressed) { camera->move_camera(engine::graphics::Camera::Movement::DOWN, dt * speedMultiplier); }
 
     auto mouse = platform->mouse();
     camera->rotate_camera(mouse.dx, mouse.dy);


### PR DESCRIPTION
Nakon što sam pokušao da zamenim postojeće skybox teksture, u sceni se i dalje prikazuje fallback (ona šarena) tekstura, umesto onoga šta sam stavio u folder. Teksture koje koristim su 256x256, što bi trebalo da bude sasvim u redu s obzirom da su to dimenzije koje su stepene dvojke.

Preimenovao sam fajlove prema očekivanom rasporedu (right, left, top, bottom, front, back), ali i dalje se učitava fallback tekstura.
Pretpostavljam da engine, u slučaju da ne pronađe odgovarajuće fajlove, koristi rezervnu teksturu, što se i dešava u mom slučaju.
Pokušao sam da vratim stare teksture, ali problem se i dalje javlja – aplikacija se ne pokreće kako treba zbog neispravnog učitavanja skyboxa.

Nisam siguran da li je problem u neodgovarajućim imenima fajlova, konfiguraciji u config.json, ili nekom drugom aspektu procesa učitavanja. Molim vas za pomoć i smernice kako da rešim ovaj problem i pravilno postavim skybox teksture.